### PR TITLE
Scaling fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Zhrnutie projektu to jednotlivých bodov
     -   [ ] Fix glitches on resize
     -   [ ] Shrinking stops when resizing
     -   [ ] Window flickering when resizing
-    -   [ ] !! On Windows, when using 125% or higher scaling, the window when game is started moves to bottom right corner of the screen and triggers game over
+    -   [x] **Temporal fix** Incorrect window position when scaling is applied on Windows: When Windows uses display scaling above 100%, it creates a mismatch between physical and logical pixel coordinates. This affects how Tauri handles window positioning
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Zhrnutie projektu to jednotlivých bodov
     -   [ ] Fix glitches on resize
     -   [ ] Shrinking stops when resizing
     -   [ ] Window flickering when resizing
-    -   [x] **Temporal fix** Incorrect window position when scaling is applied on Windows: When Windows uses display scaling above 100%, it creates a mismatch between physical and logical pixel coordinates. This affects how Tauri handles window positioning
+    -   [x] **Temporal fix:** Incorrect window position when scaling is applied on Windows: When Windows uses display scaling above 100%, it creates a mismatch between physical and logical pixel coordinates. This affects how Tauri handles window positioning
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "windowkill",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "scripts": {
     "tauri": "tauri"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4526,7 +4526,7 @@ dependencies = [
 
 [[package]]
 name = "windowkill"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windowkill"
-version = "0.2.1"
+version = "0.2.2"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schema.tauri.app/config/2",
     "productName": "windowkill",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "identifier": "com.windowkill.app",
     "build": {
         "frontendDist": "../src"

--- a/src/js/gameUtils.js
+++ b/src/js/gameUtils.js
@@ -27,6 +27,7 @@ class GameUtils {
         this.c = canvas.getContext("2d");
         this.score = 0;
         this.highScore = this.load_score();
+        this.scaleFactor = this.appWindow.scaleFactor();
     }
 
     /**
@@ -84,6 +85,7 @@ class GameUtils {
         const targetHeight = startX.height + increaseHeight;
         const deltaX = targetWidth - startX.width;
         const deltaY = targetHeight - startX.height;
+        console.log(this.scaleFactor);
 
         return new Promise((resolve) => {
             const animate = () => {
@@ -161,7 +163,7 @@ class GameUtils {
         const newY = (await this.appWindow.outerPosition()).y + decreaseAmount / 2;
 
         await this.animateWindowSize(-decreaseAmount, -decreaseAmount, 100, "shrink");
-        await this.appWindow.setPosition(new LogicalPosition(newX, newY)).catch(console.error);
+        // await this.appWindow.setPosition(new LogicalPosition(newX, newY)).catch(console.error);
 
         setTimeout(() => this.shrinkWindow(), 100);
     }

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,12 @@ window.addEventListener("DOMContentLoaded", async () => {
     const options = new Options();
     await options.initialize();
 
+    if (await appWindow.scaleFactor() > 1) {
+        alert(
+            "For best experience, please set your display scaling to 100%."
+        );
+    }
+
     // Buttons in main menu
     const startButton = document.querySelector("#startButton");
     const optionsButton = document.querySelector("#optionsButton");


### PR DESCRIPTION
This pull request addresses a critical issue with window positioning on Windows when display scaling is applied, introduces a temporary fix, and adds minor updates to the codebase. The most important changes include implementing a temporary fix for scaling-related window positioning issues, updating the application version, and adding scaling-related logic and warnings to improve the user experience.

### Fixes and improvements for scaling-related issues:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L181-R181): Documented a temporary fix for incorrect window positioning on Windows when display scaling above 100% is applied. This issue stems from a mismatch between physical and logical pixel coordinates.
* [`src/js/gameUtils.js`](diffhunk://#diff-5fe39c6c9c19f2831622192d2360dc7d46405a869bd5b78d397e70eb464ec1faR30): Introduced a new `scaleFactor` property in `GameUtils` to handle scaling logic, logged the scale factor for debugging, and commented out a problematic `setPosition` call to prevent errors during window resizing. [[1]](diffhunk://#diff-5fe39c6c9c19f2831622192d2360dc7d46405a869bd5b78d397e70eb464ec1faR30) [[2]](diffhunk://#diff-5fe39c6c9c19f2831622192d2360dc7d46405a869bd5b78d397e70eb464ec1faR88) [[3]](diffhunk://#diff-5fe39c6c9c19f2831622192d2360dc7d46405a869bd5b78d397e70eb464ec1faL164-R166)
* [`src/main.js`](diffhunk://#diff-27653c212e1cfe533e4eb2f7d0d3f89604c9de48a09583b4cbbbcbd08a07da79R13-R18): Added a warning message to alert users if their display scaling is set above 100%, recommending a 100% scaling setting for the best experience.

### Version updates:
* `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`: Updated the application version from `0.2.1` to `0.2.2` to reflect the changes and fixes introduced in this pull request. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4) [[2]](diffhunk://#diff-fe4c6a80a21e81339e2e0faeb9134d0f9636c168987df13c8abf1927a1caee39L3-R3) [[3]](diffhunk://#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7L4-R4)